### PR TITLE
fix(popup): Fix main ui update delay

### DIFF
--- a/src/scripts/components/Timer.tsx
+++ b/src/scripts/components/Timer.tsx
@@ -77,6 +77,7 @@ function TimerDuration ({ start }: { start: string }) {
   const [ duration, setDuration ] = React.useState(formatDuration(start));
 
   React.useEffect(() => {
+    setDuration(formatDuration(start));
     const timeoutId = setTimeout(() => {
       setDuration(formatDuration(start));
     }, 1000);

--- a/src/scripts/popup.js
+++ b/src/scripts/popup.js
@@ -370,6 +370,17 @@ window.PopUp = {
       request.duration = -1 * Math.floor(start.getTime() / 1000);
     }
 
+    // Update UI right away without waiting for request
+    TogglButton.$curEntry.description = document.querySelector('#toggl-button-description').value;
+    TogglButton.$curEntry.start = request.start;
+    TogglButton.$curEntry.duration = request.duration;
+    TogglButton.$curEntry.pid = selected.pid;
+    TogglButton.$curEntry.projectName = selected.name;
+    TogglButton.$curEntry.tags = PopUp.$tagAutocomplete.getSelected();
+    TogglButton.$curEntry.tid = selected.tid;
+    TogglButton.$curEntry.billable = billable;
+    PopUp.renderTimer();
+
     PopUp.sendMessage(request);
     PopUp.switchView(PopUp.$menuView);
   },


### PR DESCRIPTION
Please remember the [Contributing Guidelines](https://github.com/toggl/toggl-button/blob/master/.github/CONTRIBUTING.md) :heart:

## :star2: What does this PR do?

This PR makes the main popup UI update right after user presses "Done". That way the UI is already up to date when returning to the main view.

The main issue with duration was that it had a timer and when returning to main view the timer would still work and wait 1 second to update. I added another render call just before starting the interval timer. 

## :bug: Recommendations for testing

All changes should be tested across Chrome and Firefox.

- Start timer
- Edit entry description and duration
- Press "Done"
- Check if the data is updated right away without delay

## :memo: Links to relevant issues or information

closes #1503 
