### PR TITLE
Add support for jsonata filtering of tags and project name

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7971,6 +7971,11 @@
       "integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE=",
       "dev": true
     },
+    "jsonata": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/jsonata/-/jsonata-1.7.0.tgz",
+      "integrity": "sha512-W1qxnGXtbaboFFA8DMLL2GZgiWoeFuMo0Yf3J23o03omzIuW9a9hgowgfUChQq8bfMfh/zmQJpwn/gQirn46ew=="
+    },
     "jsonfile": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -91,6 +91,7 @@
     "@emotion/core": "10.0.10",
     "@emotion/styled": "10.0.10",
     "date-fns": "1.30.1",
+    "jsonata": "1.7.0",
     "keycode": "2.2.0",
     "lodash.map": "4.6.0",
     "lodash.reduce": "4.6.0",

--- a/src/scripts/common.js
+++ b/src/scripts/common.js
@@ -1,4 +1,5 @@
 import { ProjectAutoComplete, TagAutoComplete } from './lib/autocomplete';
+import jsonata from 'jsonata';
 const browser = require('webextension-polyfill');
 
 let projectAutocomplete; let tagAutocomplete;
@@ -7,6 +8,8 @@ window.$ = (s, elem) => {
   elem = elem || document;
   return elem.querySelector(s);
 };
+
+window.jsonata = jsonata;
 
 window.createTag = (name, className, textContent) => {
   const tag = document.createElement(name);

--- a/src/scripts/content/eventum.js
+++ b/src/scripts/content/eventum.js
@@ -1,5 +1,14 @@
 'use strict';
 
+// jsonata jsonataExpression for tags, must return an array of tags
+// @see http://docs.jsonata.org/overview.html
+const jsonataExpression = `
+  {
+    "projectName" : project.name,
+    "tags": custom_fields
+  }
+`;
+
 togglbutton.render('.issue_view:not(.toggl)', {}, function (elem) {
   const issueId = $('#issue_overview', elem).getAttribute('data-issue-id');
   const description = $('#issue_overview #issue_summary', elem).textContent;
@@ -18,8 +27,7 @@ togglbutton.render('.issue_view:not(.toggl)', {}, function (elem) {
   const link = togglbutton.createTimerLink({
     className: 'eventum',
     description: '#' + issueId + ' ' + description,
-    projectName: project,
-    tags: getTags
+    ...buildParameters(jsonataExpression, project)
   });
 
   const container = $('div#issue_menu', elem);
@@ -27,11 +35,24 @@ togglbutton.render('.issue_view:not(.toggl)', {}, function (elem) {
   container.parentNode.appendChild(spanTag.appendChild(link));
 });
 
-function getTags () {
-  const customFields = getCustomFields();
+function buildParameters (expression, projectName) {
+  const json = {
+    project: {
+      name: projectName
+    },
+    custom_fields: getCustomFields()
+  };
 
-  // for now, just return values of all custom fields
-  return Object.values(customFields);
+  let parameters = [];
+  try {
+    console.log('jsonata', json, expression);
+    parameters = window.jsonata(expression).evaluate(json);
+    console.log('jsonata result', parameters);
+  } catch (e) {
+    console.error('jsonata error', e);
+  }
+
+  return parameters;
 }
 
 /**

--- a/src/scripts/content/eventum.js
+++ b/src/scripts/content/eventum.js
@@ -18,10 +18,46 @@ togglbutton.render('.issue_view:not(.toggl)', {}, function (elem) {
   const link = togglbutton.createTimerLink({
     className: 'eventum',
     description: '#' + issueId + ' ' + description,
-    projectName: project
+    projectName: project,
+    tags: getTags
   });
 
   const container = $('div#issue_menu', elem);
   const spanTag = document.createElement('span');
   container.parentNode.appendChild(spanTag.appendChild(link));
 });
+
+function getTags () {
+  const customFields = getCustomFields();
+
+  // for now, just return values of all custom fields
+  return Object.values(customFields);
+}
+
+/**
+ * Abstract method to extract custom fields as field name => field value.
+ *
+ * @returns {{}}
+ */
+function getCustomFields () {
+  const fields = {};
+  const $rows = document.querySelectorAll('div.issue_section#custom_fields>div.content>table>tbody>tr');
+
+  if (!$rows) {
+    return fields;
+  }
+
+  for (const $row of Object.values($rows)) {
+    const $cells = $row.children;
+    const fieldName = $cells[0].textContent.trim();
+    const fieldValue = $cells[1].textContent.trim();
+
+    // Empty values have no purpose
+    if (!fieldValue) {
+      continue;
+    }
+    fields[fieldName] = fieldValue;
+  }
+
+  return fields;
+}

--- a/src/scripts/content/eventum.js
+++ b/src/scripts/content/eventum.js
@@ -45,9 +45,7 @@ function buildParameters (expression, projectName) {
 
   let parameters = [];
   try {
-    console.log('jsonata', json, expression);
     parameters = window.jsonata(expression).evaluate(json);
-    console.log('jsonata result', parameters);
   } catch (e) {
     console.error('jsonata error', e);
   }

--- a/src/scripts/content/gitlab.js
+++ b/src/scripts/content/gitlab.js
@@ -1,5 +1,15 @@
 'use strict';
 
+// jsonata jsonataExpression for tags, must return an array of tags
+// @see http://docs.jsonata.org/overview.html
+// http://try.jsonata.org/Hkg_K4EZL
+const jsonataExpression = `
+{
+  "projectName" : project.name,
+  "tags": labels
+}
+`;
+
 togglbutton.render(
   '.issue-details .detail-page-description:not(.toggl)',
   { observe: true },
@@ -21,8 +31,7 @@ togglbutton.render(
     const link = togglbutton.createTimerLink({
       className: 'gitlab',
       description: description,
-      tags: tagsSelector,
-      projectName: getProjectSelector
+      ...buildParameters(jsonataExpression)
     });
 
     actionsElem.parentElement.insertBefore(link, actionsElem);
@@ -52,8 +61,7 @@ togglbutton.render(
     const link = togglbutton.createTimerLink({
       className: 'gitlab',
       description: description,
-      tags: tagsSelector,
-      projectName: getProjectSelector
+      ...buildParameters(jsonataExpression)
     });
 
     actionsElem.parentElement.insertBefore(link, actionsElem);
@@ -74,12 +82,39 @@ function getBreadcrumbsSubTitle () {
   return $el ? $el.textContent.trim() : '';
 }
 
-function getProjectSelector () {
+function getProjectName () {
   const $el = $('.title .project-item-select-holder') || $('.breadcrumbs-list li:nth-last-child(3) .breadcrumb-item-text');
   return $el ? $el.textContent.trim() : '';
 }
 
-function tagsSelector () {
+function getProjectPath () {
+  const $el = $('a[data-qa-selector="project_link"]');
+
+  return $el ? $el.getAttribute('href') : null;
+}
+
+function buildParameters (expression) {
+  const json = {
+    project: {
+      name: getProjectName(),
+      path: getProjectPath()
+    },
+    labels: getLabels()
+  };
+
+  let parameters = [];
+  try {
+    console.log('jsonata', json, expression);
+    parameters = window.jsonata(expression).evaluate(json);
+    console.log('jsonata result', parameters);
+  } catch (e) {
+    console.error('jsonata error', e);
+  }
+
+  return parameters;
+}
+
+function getLabels () {
   const $tagList = $('div[data-qa-selector="labels_block"]');
 
   if (!$tagList) {

--- a/src/scripts/content/gitlab.js
+++ b/src/scripts/content/gitlab.js
@@ -104,9 +104,7 @@ function buildParameters (expression) {
 
   let parameters = [];
   try {
-    console.log('jsonata', json, expression);
     parameters = window.jsonata(expression).evaluate(json);
-    console.log('jsonata result', parameters);
   } catch (e) {
     console.error('jsonata error', e);
   }

--- a/src/scripts/content/gitlab.js
+++ b/src/scripts/content/gitlab.js
@@ -2,7 +2,6 @@
 
 // jsonata jsonataExpression for tags, must return an array of tags
 // @see http://docs.jsonata.org/overview.html
-// http://try.jsonata.org/Hkg_K4EZL
 const jsonataExpression = `
 {
   "projectName" : project.name,


### PR DESCRIPTION
Please remember the [Contributing Guidelines](https://github.com/toggl/toggl-button/blob/master/.github/CONTRIBUTING.md) :heart:

## :star2: What does this PR do?

Add support for [jsonata] filtering of tags and project name in Eventum and GitLab integrations.

Currently, the customization is supposed to be done with a custom build of the extension. In the future, the jsonata expression could be loaded remotely or configured in the options dialog.

[jsonata]: http://jsonata.org/

## :bug: Recommendations for testing

All changes should be tested across Chrome and Firefox.

<!-- Tips for testing this PR, or anything you want to bring special attention to. -->

## :memo: Links to relevant issues or information

Requires https://github.com/toggl/toggl-button/pull/1682 merged first

