### PR TITLE
More advanced Asana sub-task support

### DIFF
--- a/src/scripts/content/asana.js
+++ b/src/scripts/content/asana.js
@@ -138,7 +138,10 @@ togglbutton.render(
     }
 
     const descriptionSelector = () => {
-      return $('.SingleTaskPaneSpreadsheet-titleRow textarea', elem).textContent.trim();
+      return [
+        ...elem.querySelectorAll('.TaskAncestry-ancestor'),
+        $('.SingleTaskPaneSpreadsheet-titleRow textarea', elem)
+      ].map(el => el.textContent.trim()).join(' > ');
     };
 
     const projectSelector = () => {

--- a/src/scripts/content/asana.js
+++ b/src/scripts/content/asana.js
@@ -147,7 +147,7 @@ togglbutton.render(
     const projectSelector = () => {
       const ancestorProjects = elem.querySelectorAll('.TaskAncestry-ancestorProject');
       const projectEl = elem.querySelectorAll('.TaskProjectToken-potTokenizerPill');
-      return [...ancestorProjects, ...projectEl].map(el => el.textContent.trim());
+      return [...ancestorProjects, ...projectEl].map(el => el.textContent.trim()).reduce((selectors, selector) => [...selectors, ...selector.split(/\s+/)], []);
     };
 
     const tagsSelector = () => {

--- a/src/scripts/content/asana.js
+++ b/src/scripts/content/asana.js
@@ -142,8 +142,9 @@ togglbutton.render(
     };
 
     const projectSelector = () => {
+      const ancestorProjects = elem.querySelectorAll('.TaskAncestry-ancestorProject');
       const projectEl = elem.querySelectorAll('.TaskProjectToken-potTokenizerPill');
-      return [...projectEl].map(el => el.textContent.trim());
+      return [...ancestorProjects, ...projectEl].map(el => el.textContent.trim());
     };
 
     const tagsSelector = () => {


### PR DESCRIPTION
## :star2: What does this PR do?

This adds more advanced support for Asana sub-tasks. An Asana sub-task is a task that is nested under another task. Currently top-level tasks are supported, but they are slightly different than sub-tasks. Sub-tasks display the projects that their top-level ancestor belongs to in a different location, so this PR allows this location to be taken into consideration.

This PR also includes the name of ancestor tasks in the description in the same way it is displayed by Asana.

This does not change any functionality for top-level tasks, missing ancestor elements do not match anything and are ignored.
