### PR TITLE
fix(atlassian jira): Select the correct Jira issue key in board sidebar

### DIFF
--- a/src/scripts/content/atlassian.js
+++ b/src/scripts/content/atlassian.js
@@ -12,7 +12,7 @@ togglbutton.render(
     const rootElem = $('#ghx-detail-view');
     const container = createTag('div', 'jira-ghx-toggl-button');
     const titleElem = $('[spacing] h1', rootElem);
-    const numElem = $('[spacing] a', rootElem);
+    const numElem = $('[spacing]:eq(0) a:last', rootElem);
     const projectElem = $('.bgdPDV');
     let description = titleElem.textContent;
     if (numElem !== null) {


### PR DESCRIPTION
## :star2: What does this PR do?

In the Jira Board issue sidebar, when an issue has a parent issue/epic, then when The Toggle button gets placed, it takes the parent issue number (being the first `<a />`) instead of the correct issue number.

![Screenshot from 2021-03-04 13-22-22](https://user-images.githubusercontent.com/2794908/109963535-cf7af500-7cec-11eb-9f5f-7562dfa795ab.png)

The issue number in the description will be PROJ-1, which is wrong. This PR changes the code so it will pick the last one, so PROJ-3 here.

## :bug: Recommendations for testing

I have tested this on a SaaS Jira instance (at https://*.atlassian.net/). I've tried to test this on public Jira boards but couldn't find any where the piece of code would be applicable to in the first place.

## :memo: Links to relevant issues or information

Fixes #1912
