### PR TITLE
Add Tag Support to Microsoft To-Do

### DIFF
--- a/src/scripts/content/microsoft-to-do.js
+++ b/src/scripts/content/microsoft-to-do.js
@@ -15,11 +15,17 @@ togglbutton.render('.taskItem-body:not(.toggl)', { observe: true }, function (
       ? activeListTitle.textContent
       : '';
 
+  const tagsSelector = () => {
+    const tags = elem.querySelectorAll('a.link[href^="/search/%23"]');
+    return [...tags].map(tag => tag.textContent.trim().substring(1));
+  };
+
   const link = togglbutton.createTimerLink({
     className: 'microsoft-todo',
     buttonType: 'minimal',
     description: titleElem.textContent,
-    projectName: projectTitle
+    projectName: projectTitle,
+    tags: tagsSelector
   });
 
   container.appendChild(link);


### PR DESCRIPTION
Please remember the [Contributing Guidelines](https://github.com/toggl/toggl-button/blob/master/.github/CONTRIBUTING.md) :heart:

## :star2: What does this PR do?

This PR adds support for importing Tags in Microsoft To-Do: https://support.microsoft.com/en-us/office/add-steps-importance-notes-tags-and-categories-to-your-tasks-bf9fdff6-f85f-4e03-9534-c587eb32515c

The Toggl Button can now read Task's tags and add it to the Toggl task.

## :bug: Recommendations for testing

For testing this extension:

1. Enable automatic Tagging in the Extension's settings

![image](https://user-images.githubusercontent.com/2698760/114443701-5e104b00-9ba4-11eb-927f-c16a2ad1ec3a.png)

2. Create a new task in Microsoft To-Do, adding a tag to its description:

![image](https://user-images.githubusercontent.com/2698760/114443785-7bddb000-9ba4-11eb-9d7d-ea37eac11941.png)

3. Click o Toggl Button to start a timer. The Tags added to the task should now be listed in the Toggl's Tags section.
