### PR TITLE
Notion fixes

### DIFF
--- a/src/scripts/common.js
+++ b/src/scripts/common.js
@@ -583,7 +583,6 @@ window.togglbutton = {
           service: togglbutton.serviceName
         };
       } else {
-        togglbutton.activateTimerLink(link);
         opts = {
           type: 'timeEntry',
           respond: true,
@@ -596,6 +595,8 @@ window.togglbutton = {
           url: window.location.href,
           container: params.container || ''
         };
+        link.title = opts.description + (opts.projectName ? ' - ' + opts.projectName : '');
+        togglbutton.activateTimerLink(link);
       }
       togglbutton.element = e.currentTarget;
 

--- a/src/scripts/content/notion.js
+++ b/src/scripts/content/notion.js
@@ -1,13 +1,13 @@
 'use strict';
 
-// Selectors here are madness, it works for as of Dec 4th 2019
+// Selectors here are madness, it works for as of Jul 16th 2021
 // Button renders in popup/dialog view
 togglbutton.render(
   '.notion-peek-renderer:not(.toggl)',
   { observe: true },
   function (elem) {
     function getDescription () {
-      const descriptionElem = elem.querySelector('.notion-scroller .notion-selectable div[contenteditable="true"]');
+      const descriptionElem = elem.querySelector('.notion-page-block div[contenteditable]');
       return descriptionElem ? descriptionElem.textContent.trim() : '';
     }
 
@@ -35,7 +35,7 @@ togglbutton.render(
     elem.style.position = 'relative';
 
     function getDescription () {
-      const descriptionElem = elem ? elem.querySelector('div[data-root="true"]') : '';
+      const descriptionElem = elem ? elem.querySelector('div[contenteditable]') : '';
 
       return descriptionElem ? descriptionElem.textContent.trim() : '';
     }


### PR DESCRIPTION
Please remember the [Contributing Guidelines](https://github.com/toggl/toggl-button/blob/master/.github/CONTRIBUTING.md) :heart:

## :star2: What does this PR do?
Two things, actually. 

First commit is simple enough. It just fixes Notion new selectors, so that description is added properly.

The second commit fixes the way we indicate if button is running or not. Because we do some crazy mumbo-jumbo here:
https://github.com/toggl/toggl-button/blob/d1491c27442aa5fe5214bd39d29464b874b1f110/src/scripts/common.js#L637-L647

In order to determine which button instance/link is currently running. There was a problem if description was obtained *after* button creation (with a function, in dynamic page load). So it resets link `title` attribute after it creates time entry. 

## :bug: Recommendations for testing
Just check out if both issues are fixed + do some sanity test on other integrations. 

## :memo: Links to relevant issues or information
Closes ##1982
Closes #1983