### PR TITLE
fix(style): Make dark scroll bar in Chromium-based browsers

### DIFF
--- a/src/styles/colours.css
+++ b/src/styles/colours.css
@@ -1,4 +1,6 @@
 :root {
+  color-scheme: light dark;
+
   --white: #fff;
   --extra-light-grey: #f3f3f3;
   --lighter-grey: #e3e4e4;


### PR DESCRIPTION
Please remember the [Contributing Guidelines](https://github.com/toggl/toggl-button/blob/master/.github/CONTRIBUTING.md) :heart:

## :star2: What does this PR do?

Make dark scroll bar in Chromium-based browsers, since the `"chrome_style": true` in the manifest does not work for the scroll bar.

<!-- A Concise description of what this PR achieves, including any context. -->

<!-- If you're adding a new integration, please make sure it follows the "style guide" https://github.com/toggl/toggl-button/blob/master/.github/CONTRIBUTING.md -->

## :bug: Recommendations for testing

Turn on the dark theme on the system and open the extension options. And also greatly reduce the size of the browser and open a pop-up window so that a scroll bar appears in it.

<!-- Tips for testing this PR, or anything you want to bring special attention to. -->

## :memo: Links to relevant issues or information

<!-- Link to relevant issues, comments, etc. -->
