### PR TITLE
Fix naming of Google Docs/Sheets/Slides integration

### DIFF
--- a/src/origins.js
+++ b/src/origins.js
@@ -231,7 +231,7 @@ export default {
   },
   'docs.google.com': {
     url: '*://docs.google.com/*',
-    name: 'Google Docs'
+    name: "Google Docs, Sheets, Slides",
   },
   'inbox.google.com': {
     url: '*://inbox.google.com/*',


### PR DESCRIPTION
## :star2: What does this PR do?
- 04b580f - **fix(gdocs): Fix naming of Google Docs/Sheets/Slides integration**

## :bug: Recommendations for testing
 - Go to the integrations section on the Settings page, and check if the integration name now includes Docs, Sheets and Slides apps.

## :memo: Links to relevant issues or information
Closes #2040