### PR TITLE
fix(taiga): Fix taiga.io kanban view

### DIFF
--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -614,23 +614,21 @@ a.toggl-button.toggl-plan {
 }
 
 .detail-title-wrapper a.toggl-button.taiga {
-  margin: 8px 5px 0px 4px;
+  margin: 8px 5px 0 4px;
   text-decoration: none;
   flex-grow: 0;
 }
 
-.card .card-title a.toggl-button.taiga + a {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  height: 13px;
+.card .card-title.toggl {
+  display: flex;
 }
 
 .epic-row a.toggl-button,
 .card-title a.toggl-button {
-  margin: 0 0.25rem 0 0;
+  margin: 0 0.3rem 0 0;
   position: relative;
-  top: 3px;
+  top: -1px;
+  min-width: 19px;
 }
 
 .column-fold .card-title a.toggl-button.taiga.active {


### PR DESCRIPTION
## :star2: What does this PR do?

Fixes taiga.io kanban view.

Both one-line and miltiple-line cards should look okayish now:

<img width="283" alt="CleanShot 2022-02-09 at 12 53 43@2x" src="https://user-images.githubusercontent.com/4663690/153183939-0227d833-cca9-42df-b886-25d27d82e665.png">

## :bug: Recommendations for testing

Sign in to taiga.io, create a Kanban project and two cards to the board, one with a long name and one with a short name. 

They should both look good, not like in the screenshots from the issue.

All changes should be tested across Chrome and Firefox.

## :memo: Links to relevant issues or information

Closes https://github.com/toggl/track-extension/issues/1929
