### PR TITLE
fix(teamwork): Update CSS selectors for teamwork Desk

### DIFF
--- a/src/content/teamwork.js
+++ b/src/content/teamwork.js
@@ -174,3 +174,29 @@ togglbutton.render(
     root.appendChild(link);
   }
 );
+
+// Teamwork Desk - new design (March 2022)
+togglbutton.render(
+  '.ticket-view-page--container:not(.toggl)',
+  { observe: true },
+  function (elem) {
+    // ticket view
+    const container = $('.title-container', elem);
+    const id = $('.ticket-id', elem).textContent;
+    const description = $('.title__subject', elem).textContent;
+
+    const descFunc = function () {
+      return id.trim() + ' ' + description.trim();
+    };
+
+    const link = togglbutton.createTimerLink({
+      className: 'teamwork',
+      buttonType: 'minimal',
+      description: descFunc
+    });
+
+    link.style.margin = '3px 0 0 7px';
+
+    container.appendChild(link);
+  }
+);

--- a/src/content/teamwork.js
+++ b/src/content/teamwork.js
@@ -1,3 +1,9 @@
+/**
+ * @name Teamwork
+ * @urlAlias teamwork.com
+ * @urlRegex *://*.teamwork.com/*
+ */
+
 'use strict';
 
 // Tasks listing page in project

--- a/src/origins.js
+++ b/src/origins.js
@@ -588,7 +588,8 @@ export default {
   },
   'teamwork.com': {
     url: '*://*.teamwork.com/*',
-    name: 'Teamwork'
+    name: 'Teamwork',
+    file: 'teamwork.js'
   },
   'teamworkpm.net': {
     url: '*://*.teamworkpm.net/*',


### PR DESCRIPTION
## :star2: What does this PR do?

<!-- A Concise description of what this PR achieves, including any context. -->
Teamwork Desk was no longer showing the Toggl as expected [from our documentation](https://github.com/toggl/track-extension/wiki/Where-can-I-find-the-Button%3F#teamwork-desk)

I've updated the CSS selector in a new version just like it was done before with previous versions,
Here is what it looks like now:


![image](https://user-images.githubusercontent.com/22992043/156476664-91e6e4d2-f1ec-46fe-8dcc-87aa0a185197.png)


<!-- If you're adding a new integration, please make sure it follows the "style guide" https://github.com/toggl/toggl-button/blob/master/.github/CONTRIBUTING.md -->

## :bug: Recommendations for testing

All changes should be tested across Chrome and Firefox.

<!-- Tips for testing this PR, or anything you want to bring special attention to. -->

## :memo: Links to relevant issues or information

<!-- Link to relevant issues, comments, etc. -->
Closes #2015 
