### PR TITLE
fix(notion): Add extracting description from breadcrumbs as a fallback

### DIFF
--- a/src/content/notion.js
+++ b/src/content/notion.js
@@ -1,3 +1,8 @@
+/**
+ * @name Notion
+ * @urlAlias notion.so
+ * @urlRegex *://*.notion.so/*
+ */
 'use strict';
 
 function createWrapper (link) {
@@ -43,18 +48,24 @@ togglbutton.render(
 
     function getDescription () {
       const controls = document.querySelector('.notion-page-controls');
-      if (!controls) return '';
-
+      const topBar = document.querySelector('.notion-topbar');
       let title = '';
 
-      if (controls.nextElementSibling) {
-        title = controls.nextElementSibling;
-      } else {
-        const parent = controls.parentElement;
+      if (controls) {
+        if (controls.nextElementSibling) {
+          title = controls.nextElementSibling;
+        } else {
+          const parent = controls.parentElement;
 
-        if (!parent) return '';
+          if (!parent) return '';
 
-        title = parent ? parent.nextElementSibling : '';
+          title = parent ? parent.nextElementSibling : '';
+        }
+      } else if (topBar) {
+        const breadcrumbs = topBar.querySelector('div > .notranslate')
+        if (breadcrumbs) {
+          title = breadcrumbs.childNodes[breadcrumbs.childNodes.length - 1].querySelector('.notranslate:last-child')
+        }
       }
 
       return title ? title.textContent.trim() : '';


### PR DESCRIPTION
## :star2: What does this PR do?

The root cause of the issue was in missing `title` attribute on the button. The title is set during the TB initalization based on the description derived from the page content.

In Notion description is extracted from the page main section. There are cases where Toggl Button renders before the main section and it cannot get the description during the initialization. 

The same title is available in the breadcrumbs that are rendered along with the Toggl Button is the top bar. As a fallback, I added extracting the description from the breadcrumbs last text value.

## :bug: Recommendations for testing

Go to [this page](https://www.notion.so/toggl/Support-Team-2b9bb02020ed4efa891ec96d0cceafdb) and run the timer.

Once the popdown is hidden, the button text should be "Stop timer".


## :memo: Links to relevant issues or information

Closes https://github.com/toggl/track-extension/issues/2068