### PR TITLE
Add linear integration

### DIFF
--- a/src/content/linear.js
+++ b/src/content/linear.js
@@ -1,0 +1,34 @@
+'use strict';
+/**
+ * @name Linear
+ * @urlAlias linear.app
+ * @urlRegex *://linear.app/*
+ */
+
+// Add linear integration in board view only
+togglbutton.render(
+  'a[data-rbd-draggable-id]:not(.toggl)',
+  { observe: true },
+  function (elem) {
+    const id = elem.querySelector('div:first-child>div:first-child>div:first-child>span:first-child')?.textContent?.split('›')[0];
+    const title = elem.querySelector('div:first-child>div:first-child>div:first-child>span:first-child+div')?.textContent;
+
+    // Project selection only works if an existing Toggl project matches the name of the project from the linear card
+    const project = elem.querySelector(':scope>div:first-child>div:nth-child(2)>div:not(:first-child):not([role="button"])>span:only-child>div:only-child[role="button"]>div+span[type="micro"]')?.textContent;
+
+    // Gets the labels on the card as a string array.
+    const labels = [...elem.querySelectorAll(':scope>div:first-child>div:nth-child(2)>div:not([role="button"])>div[role="button"]')].map((n)=>n.textContent)
+
+    const link = togglbutton.createTimerLink({
+      description: title,
+      buttonType: 'minimal', // button type, if skipped will render full size
+      projectName: project,
+      // For some reason, tag selection isn't working even if the like-named tags have already been created in Toggl
+      tags: [id, ...labels],
+    });
+    link.style.right = '13px';
+    link.style.position = 'fixed';
+    elem.appendChild(link);
+  }
+);
+

--- a/src/content/linear.js
+++ b/src/content/linear.js
@@ -5,9 +5,36 @@
  * @urlRegex *://linear.app/*
  */
 
+// Add linear integration in table view only
+togglbutton.render(
+  'a[data-dnd-dragging]:not(.toggl)',
+  { observe: true },
+  function (elem) {
+    const idElem = elem.querySelector('span[data-column-id="issueId"]');
+    const id = idElem ? idElem.textContent : '';
+    const titleElem = idElem.parentElement.nextSibling;
+    const title = titleElem ? titleElem.textContent : '';
+
+    const link = togglbutton.createTimerLink({
+      description: title,
+      className: 'linear-table',
+      buttonType: 'minimal', // button type, if skipped will render full size
+    });
+    const existingTogglButton = elem.querySelector('.toggl-button');
+    if (existingTogglButton) {
+      // we need to remove any existing toggl buttons
+      existingTogglButton.replaceChildren(link);
+
+      return;
+    }
+    titleElem.parentElement.insertBefore(link, titleElem.nextSibling);
+  }
+);
+
+
 // Add linear integration in board view only
 togglbutton.render(
-  'a[data-rbd-draggable-id]:not(.toggl)',
+  'a[data-board-item]:not(.toggl)',
   { observe: true },
   function (elem) {
     const id = elem.querySelector('div:first-child>div:first-child>div:first-child>span:first-child')?.textContent?.split('›')[0];
@@ -26,9 +53,10 @@ togglbutton.render(
       // For some reason, tag selection isn't working even if the like-named tags have already been created in Toggl
       tags: [id, ...labels],
     });
+    elem.style.position = 'relative';
+    link.style.bottom = '13px';
     link.style.right = '13px';
-    link.style.position = 'fixed';
+    link.style.position = 'absolute';
     elem.appendChild(link);
   }
 );
-

--- a/src/origins.js
+++ b/src/origins.js
@@ -312,6 +312,11 @@ export default {
     url: '*://www.khanacademy.org/*',
     name: 'KhanAcademy'
   },
+  'linear.app': {
+    url: '*://linear.app/*',
+    name: 'Linear',
+    file: 'linear.js'
+  },
   'app.liquidplanner.com': {
     url: '*://app.liquidplanner.com/*',
     name: 'Liquidplanner'

--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -1484,3 +1484,9 @@ body.notion-body.dark .toggl-button.notion {
 .toggl-button.bugsnag {
   margin-left: 1rem;
 }
+
+
+/********* Linear *********/
+.toggl-button.linear-table {
+  margin-top: 5px;
+}


### PR DESCRIPTION
Add an integration with Linear (project management / issue tracking tool). This adds a toggl track button in the board view only, and inserts the issue title, project name (as project), and issue ID + labels (as tags), when the button is clicked.

Right now they don't have semantic markup which results in some pretty nasty selectors.

Debugging showed the expected tags were getting sent to the `togglbutton.createTimerLink` options, but the "Toggl tags" aren't getting selected in the time entry that gets started (even if those tags have already been created). Perhaps this is an issue with the Toggl extension itself?

I asked the Linear team to add some semantic classes, `data-*` attributes, or even `aria-` roles that could be used to construct less brittle selectors, so I'll update this PR (or submit a new one) to improve things if they're willing to oblige.

