### PR TITLE
fix(zendesk): Toggl button showing in 2 different places

### DIFF
--- a/src/content/zendesk.js
+++ b/src/content/zendesk.js
@@ -8,7 +8,7 @@
 
 // Zendesk new UI Jul 2021
 togglbutton.render(
-  '.omni-conversation-pane>div>div:not(.toggl)',
+  '.omni-conversation-pane>div>div:first-child:not(.toggl)',
   { observe: true },
   (elem) => {
     const getProject = () => {

--- a/src/origins.js
+++ b/src/origins.js
@@ -108,6 +108,11 @@ export default {
     url: '*://*.corgee.com/*',
     name: 'Corgee'
   },
+  'crowdin.com': {
+    url: '*://*.crowdin.com/*',
+    name: 'Crowdin',
+    file: 'crowdin.js'
+  },
   'desk.com': {
     url: '*://*.desk.com/web/agent/*',
     name: 'Desk.com'
@@ -176,7 +181,7 @@ export default {
   },
   'fastmail.com': {
     url: '*://*.fastmail.com/*',
-    name: 'Fastmail',
+    name: 'Fastmail'
   },
   'feedly.com': {
     url: '*://*.feedly.com/*',
@@ -758,10 +763,5 @@ export default {
   'zube.io': {
     url: '*://zube.io/*',
     name: 'Zube'
-  },
-  'crowdin.com': {
-    url: '*://*.crowdin.com/*',
-    name: 'Crowdin',
-    file: 'crowdin.js'
-  },
+  }
 };


### PR DESCRIPTION
## :star2: What does this PR do?
Prevent zendesk button from render in 2 different places

<!-- If you're adding a new integration, please make sure it follows the "style guide" https://github.com/toggl/toggl-button/blob/master/.github/CONTRIBUTING.md -->

## :bug: Recommendations for testing
1. Go to Zendesk task view
2. Toggl button should appear only in the header

## :memo: Links to relevant issues or information
Closes #2111