### PR TITLE
feat: Add AtCoder integration

### DIFF
--- a/src/content/atcoder.js
+++ b/src/content/atcoder.js
@@ -1,0 +1,30 @@
+/**
+ * @name AtCoder
+ * @urlAlias atcoder.jp
+ * @urlRegex *://*.atcoder.jp/*
+ */
+"use strict";
+
+togglbutton.render(
+  ".contest-duration:not(.toggl)",
+  { observe: true },
+  function (elem) {
+    const getDescription = () => {
+      const contestTitle = document.querySelector(".contest-title").innerText;
+      // .contest-title is in only contest page
+
+      const problemTitle = document.title;
+      if (problemTitle.includes(contestTitle)) {
+        // in contest top page, problemTitle includes contest title. so not need it.
+        return contestTitle;
+      }
+      return `${problemTitle} - ${contestTitle}`;
+    };
+
+    const link = togglbutton.createTimerLink({
+      description: getDescription(),
+    });
+
+    elem.appendChild(link);
+  }
+);

--- a/src/origins.js
+++ b/src/origins.js
@@ -17,6 +17,11 @@ export default {
     url: '*://*.assembla.com/*',
     name: 'Assembla'
   },
+  'atcoder.jp': {
+    url: '*://*.atcoder.jp/*',
+    name: 'AtCoder',
+    file: 'atcoder.js'
+  },
   'atlassian.com': {
     url: '*://*.atlassian.com/*',
     name: 'Atlassian / Jira',


### PR DESCRIPTION
Please remember the [Contributing Guidelines](https://github.com/toggl/track-extension/blob/master/docs/CONTRIBUTING.md) :heart:

## :star2: What does this PR do?
Adds the timer to [AtCoder](https://atcoder.jp/?lang=en), in the header in only contest page.  Please review code 🙏 

AtCoder is competitive programming sites.

I tested on both Chrome and Firefox and worked correctly.

Screenshots below are taken in [https://atcoder.jp/contests/abc261](https://atcoder.jp/contests/abc261).

### Contest top page

Input only `contest title`.

![image](https://user-images.githubusercontent.com/65804288/185611512-cb25da42-9b6e-4137-91b8-7006b8aa2d61.png)


### Contest problem page

Input `problem title` and `contest title`.

![image](https://user-images.githubusercontent.com/65804288/185611571-e049d2e2-0468-42c0-82ea-74b5e5ab4c49.png)


<!-- A Concise description of what this PR achieves, including any context. -->

<!-- If you're adding a new integration, please make sure it follows the "style guide" https://github.com/toggl/toggl-button/blob/master/.github/CONTRIBUTING.md -->

## :bug: Recommendations for testing

All changes should be tested across Chrome and Firefox.

<!-- Tips for testing this PR, or anything you want to bring special attention to. -->

## :memo: Links to relevant issues or information

<!-- Link to relevant issues, comments, etc. -->
