### PR TITLE
[gitlab]: Fix selector for sidebar time-tracker class

### DIFF
--- a/src/content/gitlab.js
+++ b/src/content/gitlab.js
@@ -1,5 +1,6 @@
 'use strict';
 
+// Render on issue page
 togglbutton.render(
   '.issue-details .detail-page-description:not(.toggl)',
   { observe: true },
@@ -14,6 +15,7 @@ togglbutton.render(
   }
 );
 
+// Render on merge request page
 togglbutton.render(
   '.merge-request > .detail-page-header:not(.toggl)',
   { observe: true },

--- a/src/content/gitlab.js
+++ b/src/content/gitlab.js
@@ -11,7 +11,7 @@ togglbutton.render(
     const description = [prefix, getTitle(elem)].filter(Boolean).join(' ');
 
     insertButton($('.detail-page-header-actions'), description, true);
-    insertButton($('.time_tracker'), description);
+    insertButton($('.time-tracker'), description);
   }
 );
 
@@ -26,7 +26,7 @@ togglbutton.render(
     const description = [prefix, getTitle(elem)].filter(Boolean).join(' ');
 
     insertButton($('.detail-page-header-actions'), description, true);
-    insertButton($('.time_tracker'), description);
+    insertButton($('.time-tracker'), description);
   }
 );
 


### PR DESCRIPTION
## :star2: What does this PR do?

Restore the button that has been gone for a while:

<img width="268" alt="image" src="https://user-images.githubusercontent.com/199095/213477942-96c582e2-df11-45b4-a394-cf6f7e2036be.png">

I was reported internally by our project manager to your project manager, but no action came out of it, even the issue I had to create myself half year later:
- https://github.com/toggl/track-extension/issues/2140

and yet no action to that either, so here's my attempt to do your job what we pay you.

## :bug: Recommendations for testing

All changes should be tested across Chrome and Firefox.

<!-- Tips for testing this PR, or anything you want to bring special attention to. -->

## :memo: Links to relevant issues or information

Fixes https://github.com/toggl/track-extension/issues/2140