### PR TITLE
fix(trello): Fix projects selector

### DIFF
--- a/src/content/trello.js
+++ b/src/content/trello.js
@@ -2,7 +2,7 @@
 /* global createTag */
 
 const getProject = () => {
-  const project = $('.board-header-btn-text');
+  const project = document.querySelector('.board-header [data-testid="board-name-display"]')
   return project ? project.textContent.trim() : '';
 };
 


### PR DESCRIPTION


## :star2: What does this PR do?
- [fix(trello): Fix projects selector](https://github.com/toggl/track-extension/commit/8dca22f9daa8fd5930e6e3871b9b36fb57af9199)

## :bug: Recommendations for testing
- Go to Trello with the Track Extension enabled
- Click the button on a task, and the project should be selected (if there is a equivalent project on Toggl Track).

## :memo: Links to relevant issues or information

Closes #2202
