### PR TITLE
fix(clickup): Remove space between # and task id

### DIFF
--- a/src/content/clickup.js
+++ b/src/content/clickup.js
@@ -6,9 +6,18 @@ togglbutton.render('#timeTrackingItem:not(.toggl)', { observe: true }, function 
   const description = $('.task-name', elem).textContent;
   const project = $('.space-name', elem).textContent;
 
+  const descriptionParts = description?.split('#')
+
+  const formattedDescription = descriptionParts?.reduce((acc, value, index) => {
+    if (index === descriptionParts.length - 1)
+      return acc += `#${value.trim()}`
+    else
+      return acc += `#${value}`
+  }, '')
+
   const link = togglbutton.createTimerLink({
     className: 'clickup',
-    description: description,
+    description: formattedDescription,
     projectName: project,
     buttonType: 'minimal'
   });


### PR DESCRIPTION

## :star2: What does this PR do?
- [fix(clickup): Remove space between # and task id](https://github.com/toggl/track-extension/commit/8888542aa31dc5e5892438235985b31ddcb13357)

## :bug: Recommendations for testing
There's not really a way to test this since I can't reproduce, but by the user's complaint it should fix the issue.

## :memo: Links to relevant issues or information
Related #2170

