### PR TITLE
Add support for non-english zendesk

### DIFF
--- a/src/content/zendesk.js
+++ b/src/content/zendesk.js
@@ -20,14 +20,14 @@ setTimeout(() => {
       const getDescription = () => {
         const ticketId = document.querySelector('header div[data-selected=true]').attributes['data-entity-id'].value || ''
 
-		const language = document.querySelector("html").lang || 'en'
+        const language = document.querySelector("html").lang || 'en'
 
-		const translations = {
-			'en': 'Subject',
-			'de': "Betreff"
-		}
+        const translations = {
+          'en': 'Subject',
+          'de': "Betreff"
+        }
 
-		const elementName = translations[language] || 'Subject'
+        const elementName = translations[language] || 'Subject'
         const input = elem.querySelector('input[aria-label='+elementName+']');
         const title = (input ? input.value : '').trim();
 

--- a/src/content/zendesk.js
+++ b/src/content/zendesk.js
@@ -89,6 +89,7 @@ setTimeout(() => {
     function (elem) {
       let description;
       const projectName = $('title').textContent;
+
       const titleFunc = function () {
         const titleElem = $('.editable .ember-view input', elem);
         const ticketNum = location.href.match(/tickets\/(\d+)/);

--- a/src/content/zendesk.js
+++ b/src/content/zendesk.js
@@ -20,7 +20,15 @@ setTimeout(() => {
       const getDescription = () => {
         const ticketId = document.querySelector('header div[data-selected=true]').attributes['data-entity-id'].value || ''
 
-        const input = elem.querySelector('input[aria-label=Subject]');
+		const language = document.querySelector("html").lang || 'en'
+
+		const translations = {
+			'en': 'Subject',
+			'de': "Betreff"
+		}
+
+		const elementName = translations[language] || 'Subject'
+        const input = elem.querySelector('input[aria-label='+elementName+']');
         const title = (input ? input.value : '').trim();
 
         return [`#${ticketId}`, title].filter(Boolean).join(' ');
@@ -142,13 +150,13 @@ setTimeout(() => {
       if (elem.querySelector('.toggl-button')) return;
       // If we can't get the description on this pass, let's skip and wait for the next one
       if (!getDescription()) return;
-  
+
       const link = togglbutton.createTimerLink({
         className: 'zendesk-agent-ws',
         description: getDescription
       });
-  
+
       elem.prepend(link);
     }
-  );  
+  );
 }, 1000);

--- a/src/content/zendesk.js
+++ b/src/content/zendesk.js
@@ -20,15 +20,7 @@ setTimeout(() => {
       const getDescription = () => {
         const ticketId = document.querySelector('header div[data-selected=true]').attributes['data-entity-id'].value || ''
 
-        const language = document.querySelector("html").lang || 'en'
-
-        const translations = {
-          'en': 'Subject',
-          'de': "Betreff"
-        }
-
-        const elementName = translations[language] || 'Subject'
-        const input = elem.querySelector('input[aria-label='+elementName+']');
+        const input = elem.querySelector('input[data-test-id=omni-header-subject]')
         const title = (input ? input.value : '').trim();
 
         return [`#${ticketId}`, title].filter(Boolean).join(' ');
@@ -97,7 +89,6 @@ setTimeout(() => {
     function (elem) {
       let description;
       const projectName = $('title').textContent;
-
       const titleFunc = function () {
         const titleElem = $('.editable .ember-view input', elem);
         const ticketNum = location.href.match(/tickets\/(\d+)/);


### PR DESCRIPTION
Please remember the [Contributing Guidelines](https://github.com/toggl/track-extension/blob/master/docs/CONTRIBUTING.md) :heart:

## :star2: What does this PR do?
We are using the Zendesk UI from 2021. The Toggl integration is working, but only fetching the ticket number and not the name. But the title would be really helpful for us.
Currently Toggl is searching for an element with aria-label Subject. But this does not exist in the German version of Zendesk, as is named Betreff.
This PR fetches the language of Zendesk from the `<html>` node, reads the correct Label-Name from the translation array (which can be extended for other languages) and the reads the title.

<!-- If you're adding a new integration, please make sure it follows the "style guide" https://github.com/toggl/toggl-button/blob/master/.github/CONTRIBUTING.md -->

## :bug: Recommendations for testing
You would need to test the Toggle integration in Zendesk with english and german language. Toggle schould add the ticket id and subject for tracking.

## :memo: Links to relevant issues or information

<!-- Link to relevant issues, comments, etc. -->
