### PR TITLE
Add "Azure DevOps" to Azure

### DIFF
--- a/src/origins.js
+++ b/src/origins.js
@@ -607,7 +607,7 @@ export default {
   },
   'azure.com': {
     url: '*://*.azure.com/*',
-    name: 'VisualStudio'
+    name: 'VisualStudio / Azure DevOps'
   },
   'app.vivifyscrum.com': {
     url: '*://app.vivifyscrum.com/*',


### PR DESCRIPTION
VisualStudio online planning suite is now named "Azure Devops", make it easier to find