### PR TITLE
fix gitea selectors for v1.18

### DIFF
--- a/src/content/gitea.js
+++ b/src/content/gitea.js
@@ -16,7 +16,7 @@ togglbutton.render('.time-desc:not(.toggl)',
 
 function descriptionSelector () {
   const description = document.getElementById('issue-title');
-  const issueId = description.previousElementSibling;
+  const issueId = description.nextElementSibling;
   return `${issueId.textContent} ${description.textContent}`;
 }
 
@@ -28,10 +28,10 @@ function projectSelector () {
 function tagsSelector () {
   const $tags = document.getElementsByClassName('labels')[0].children;
   var $result = [];
-  $tags.forEach(element => {
+  for (element of $tags) {
     if (element.children.length > 0 && !element.children[0].classList.contains("hide")) {
       $result.push(element.children[0].textContent);
     }
-  });
+  }
   return $result;
 }

--- a/src/content/gitea.js
+++ b/src/content/gitea.js
@@ -17,7 +17,7 @@ togglbutton.render('.time-desc:not(.toggl)',
 function descriptionSelector () {
   const description = document.getElementById('issue-title');
   const issueId = description.nextElementSibling;
-  return `${issueId.textContent} ${description.textContent}`;
+  return `${issueId.textContent.trim()} ${description.textContent.trim()}`;
 }
 
 function projectSelector () {
@@ -30,7 +30,7 @@ function tagsSelector () {
   var $result = [];
   for (var element of $tags) {
     if (element.children.length > 0 && !element.children[0].classList.contains("hide")) {
-      $result.push(element.children[0].textContent);
+      $result.push(element.children[0].textContent.trim());
     }
   }
   return $result;

--- a/src/content/gitea.js
+++ b/src/content/gitea.js
@@ -26,9 +26,9 @@ function projectSelector () {
 }
 
 function tagsSelector () {
-  const $tags = document.getElementsByClassName('labels')[0].children;
+  const $tags = document.getElementsByClassName('labels-list')[0].children;
   var $result = [];
-  for (element of $tags) {
+  for (var element of $tags) {
     if (element.children.length > 0 && !element.children[0].classList.contains("hide")) {
       $result.push(element.children[0].textContent);
     }


### PR DESCRIPTION
## :star2: What does this PR do?

This PR fixes the Gitea integration for newer versions for Gitea which have reformatted the issue page.

When debugging the original code, there are two problems:

- the issue id appears after the title not before it as the code expects
- HTMLCollection of tags does not support forEach

These changes have been made.

## :bug: Recommendations for testing

All changes should be tested across Chrome and Firefox.

These are fixes for Gitea v1.18. I will test against the latest version v1.19 once we update.

## :memo: Links to relevant issues or information

#2209
