### PR TITLE
fix(trello): Fix button on dark mode

### DIFF
--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -164,7 +164,7 @@ SingleTaskPaneToolbar .toggl-button.asana-board, /* new ui v1 */
 .toggl-button.trello {
   text-decoration: none;
   cursor: pointer;
-  color: #737373;
+  color: var(--ds-text) !important;
 }
 
 .toggl-button.trello:not(.toggl-button-edit-form-button) svg {


### PR DESCRIPTION
## :star2: What does this PR do?

## :bug: Recommendations for testing
- Go to Trello and enable dark mode (only available in some accounts)
- The button's text should look 👌 
- Test it with other Trello's themes and it should also look 👌 

## :memo: Links to relevant issues or information
<!-- Link to relevant issues, comments, etc. -->
Closes #2201