### PR TITLE
Fixes  #2246 -  ClickUp integration the task ID is detected incorrectly

### DIFF
--- a/src/content/clickup.js
+++ b/src/content/clickup.js
@@ -5,13 +5,13 @@ togglbutton.render('#timeTrackingItem:not(.toggl)', { observe: true }, function 
 ) {
 
   const description = document.querySelector('title').textContent.split('|')[0];
-  const taskID = document.querySelector('div[role="dialog"]').getAttribute('data-task-id');
+  const taskID = document.querySelector('title').textContent.split('|')[1];
 
   const project = elem.querySelector('.space-name').textContent;
 
   const link = togglbutton.createTimerLink({
     className: 'clickup',
-    description: `${description} - #${taskID}`,
+    description: `${description}-#${taskID}`,
     projectName: project,
     buttonType: 'minimal'
   });


### PR DESCRIPTION

## :star2: What does this PR do?

Gets the ClickUp task ID from the title instead of an unexisting ID.

## :bug: Recommendations for testing

Unable to test it because developer mode doesn't work

## :memo: Links to relevant issues or information

https://github.com/toggl/track-extension/issues/2246
