### PR TITLE
fix(notion): Fix Notion's page title grabbing when opened in "side peek" mode

### DIFF
--- a/src/content/notion.js
+++ b/src/content/notion.js
@@ -20,7 +20,7 @@ togglbutton.render(
   { observe: true },
   function (elem) {
     function getDescription () {
-      const descriptionElem = elem.querySelector('.notion-scroller .notion-selectable div[contenteditable="true"]');
+      const descriptionElem = elem.querySelector('.notion-peek-renderer .notion-scroller h1[contenteditable]');
       return descriptionElem ? descriptionElem.textContent.trim() : '';
     }
 


### PR DESCRIPTION
## :star2: What does this PR do?

<!-- A Concise description of what this PR achieves, including any context. -->
Fixing the following bug report.
### 🐛 Bug Report
If we fully open and I start the timer from a Notion page, it does grab the title. But if the page (database item) is opened in "side peek" mode, the timer does not grab the title.

### Expected behavior
We must get page titles both for full-opened and "side peek" pages.

### To reproduce
Steps to reproduce the behavior:

Open a database item in "side peek"
Start tracking time

<!-- If you're adding a new integration, please make sure it follows the "style guide" https://github.com/toggl/toggl-button/blob/master/.github/CONTRIBUTING.md -->

## :bug: Recommendations for testing

![2024-01-06_08-05](https://github.com/toggl/track-extension/assets/5307506/db8d1aa5-84ac-4e78-950b-89ac8de47868)

![2024-01-06_08-41](https://github.com/toggl/track-extension/assets/5307506/e1471280-aa76-4010-89f1-d739438e6a2c)

1. Open Notion page in "side peek" mode.
2. Press the Toggl Track "Start timer" button.
3. The Notion page title should be used as the description in the Toggl Track popup.

<!-- Tips for testing this PR, or anything you want to bring special attention to. -->

## :memo: Links to relevant issues or information

<!-- Link to relevant issues, comments, etc. -->
Closes #2260
