### PR TITLE
fix(google-calendar): Remove Toggl button from "Create event" on GCal

### DIFF
--- a/src/content/google-calendar.js
+++ b/src/content/google-calendar.js
@@ -39,9 +39,15 @@ togglbutton.render(rootLevelSelectors, { observe: true }, elem => {
     }
 
     const closeButton = $('[aria-label]:first-child', elem);
+    const titleSpan = $('span[role="heading"]', elem);
+
+    const isCreateEventDialog = titleSpan === null;
+    if (isCreateEventDialog) {
+      // We shouldn't add Toggl button for "Create Event" dialog.
+      return;
+    }
 
     getDescription = () => {
-      const titleSpan = $('span[role="heading"]', elem);
       return titleSpan ? titleSpan.textContent.trim() : '';
     };
     target = closeButton.parentElement.parentElement.nextSibling; // Left of the left-most action


### PR DESCRIPTION
## :star2: What does this PR do?

This change removes the Toggl button from "Create event" on Google Calendar: #2239

Before fix:
![2024-01-20_09-46](https://github.com/toggl/track-extension/assets/5307506/e97bb526-d9ba-4bce-a4f5-f8e0283ad6a3)

After fix:
![2024-01-20_09-47](https://github.com/toggl/track-extension/assets/5307506/73a86d09-d275-4d6e-a3b9-6f2c28e557e1)

<!-- A Concise description of what this PR achieves, including any context. -->

<!-- If you're adding a new integration, please make sure it follows the "style guide" https://github.com/toggl/toggl-button/blob/master/.github/CONTRIBUTING.md -->

## :bug: Recommendations for testing

<!-- Tips for testing this PR, or anything you want to bring special attention to. -->
The Toggl button shouldn't show up on the "Create event" dialog.

## :memo: Links to relevant issues or information

<!-- Link to relevant issues, comments, etc. -->
Closes https://github.com/toggl/track-extension/issues/2239
