### PR TITLE
fix(youtrack): Fix Toggl button disappeared after UI update

### DIFF
--- a/src/content/youtrack.js
+++ b/src/content/youtrack.js
@@ -44,6 +44,32 @@ togglbutton.render(
   }
 );
 
+/* new view for single issues — since YouTrack 2023.3 */
+togglbutton.render(
+  'div[data-test="issue-container"]:not(.toggl)',
+  { observe: true },
+  function (elem) {
+    const reporterInfo = elem.querySelector('span[data-test="reporter-info"]');
+    if (reporterInfo === null) {
+      return;
+    }
+    const reporterInfoContainer = reporterInfo.parentElement;
+
+    const issueIdElem = reporterInfoContainer.querySelector('a[href*="issue/"] > span');
+    const issueId = issueIdElem ? issueIdElem.textContent.trim() : "";
+
+    const issueTitleElem = elem.querySelector('h1');
+    const issueTitle = issueTitleElem ? issueTitleElem.textContent.trim() : "";
+
+    const link = togglbutton.createTimerLink({
+      description: issueId + ' ' + issueTitle,
+      projectName: issueId.split('-')[0]
+    });
+
+    reporterInfoContainer.insertBefore(link, reporterInfo);
+  }
+);
+
 // Agile board
 togglbutton.render('.yt-agile-card:not(.toggl)', { observe: true }, function (
   elem

--- a/src/content/youtrack.js
+++ b/src/content/youtrack.js
@@ -49,8 +49,10 @@ togglbutton.render(
   'div[data-test="issue-container"]:not(.toggl)',
   { observe: true },
   function (elem) {
+    console.log('Toggl Button: Reporter info not found.')
     const reporterInfo = elem.querySelector('span[data-test="reporter-info"]');
     if (reporterInfo === null) {
+      console.log('Toggl Button: Reporter info not found.')
       return;
     }
     const reporterInfoContainer = reporterInfo.parentElement;

--- a/src/origins.js
+++ b/src/origins.js
@@ -664,8 +664,8 @@ export default {
     name: 'Xero',
     file: 'xero.js'
   },
-  'myjetbrains.com': {
-    url: '*://*.myjetbrains.com/*',
+  'jetbrains.com': {
+    url: '*://*.jetbrains.com/*',
     name: 'YouTrack',
     file: 'youtrack.js'
   },


### PR DESCRIPTION
## :star2: What does this PR do?
Fix Toggl button disappeared after UI update: https://github.com/toggl/track-extension/issues/2265

### Before fix:
![2024-01-23_09-50](https://github.com/toggl/track-extension/assets/5307506/80ee5f83-937a-4ecc-b115-d76aecc532e3)

### After fix:
![2024-01-23_09-30](https://github.com/toggl/track-extension/assets/5307506/36f8a324-392a-491b-bf4f-7d7e4b191006)

![2024-01-23_09-30_1](https://github.com/toggl/track-extension/assets/5307506/fb404904-7055-4c76-96a3-7aff54b2e97b)

<!-- A Concise description of what this PR achieves, including any context. -->

<!-- If you're adding a new integration, please make sure it follows the "style guide" https://github.com/toggl/toggl-button/blob/master/.github/CONTRIBUTING.md -->

## :bug: Recommendations for testing
The Toggl button should appear on the issue page.
I tested the fix on the public Jetbrains Youtrack: https://youtrack.jetbrains.com/issues

<!-- Tips for testing this PR, or anything you want to bring special attention to. -->

## :memo: Links to relevant issues or information

<!-- Link to relevant issues, comments, etc. -->
Closes https://github.com/toggl/track-extension/issues/2265
