### PR TITLE
fix(github): Fix Toggl button isn't visible on an issue popup

### DIFF
--- a/src/content/github.js
+++ b/src/content/github.js
@@ -65,26 +65,28 @@ togglbutton.render(
   'div[role="dialog"]:not(.toggl)',
   { observe: true },
   async function (elem) {
-    const projectElem = document.querySelector("#memexTitleInput");
+    const projectElem = document.querySelector("div[role='navigation'] h1");
 
-    const parent = document.querySelector("dl");
     const description = await getPaneDescription(elem);
+    const targetParent = document.querySelector("div[data-testid='issue-viewer-metadata-container']");
+    const targetChildSection = targetParent && targetParent.querySelector("div[data-testid='sidebar-section']");
+
+    if (targetChildSection === null) {
+      return;
+    }
 
     const div = document.createElement("div");
-    div.classList = parent.children[0].classList.value;
-    div.style.paddingLeft = "16px";
-
-    let projectName = "";
-    if (projectElem) projectName = projectElem.value;
+    div.className = targetChildSection.className;
+    div.style.paddingLeft = "8px";
 
     const link = togglbutton.createTimerLink({
       className: "github",
       description: description,
-      projectName: projectName,
+      projectName: projectElem ? projectElem.textContent.trim() : "",
     });
 
     div.appendChild(link);
-    parent.prepend(div);
+    targetParent.prepend(div);
   }
 );
 


### PR DESCRIPTION
## :star2: What does this PR do?
Fix Toggl button isn't visible on an issue popup: #2269

<!-- A Concise description of what this PR achieves, including any context. -->

<!-- If you're adding a new integration, please make sure it follows the "style guide" https://github.com/toggl/toggl-button/blob/master/.github/CONTRIBUTING.md -->

## :bug: Recommendations for testing

### Expected behaviour
Toggl button should be visible on top of assignees section in a issue pop-up.

### Steps to reproduce
Steps to reproduce the behaviour:

1. Go to a GitHub project
2. Click on an issue and open a popup

<!-- Tips for testing this PR, or anything you want to bring special attention to. -->

## :memo: Links to relevant issues or information
Closes #2269

<!-- Link to relevant issues, comments, etc. -->
