### PR TITLE
[DO NOT MERGE] fix(notion): Button is slightly misaligned

### DIFF
--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -1306,6 +1306,7 @@ body.notion-body.dark .toggl-button-notion-wrapper:hover {
 .toggl-button.notion {
   color: rgb(55, 53, 47);
   text-decoration: none;
+  padding-top: 5px;
 }
 
 body.notion-body.dark .toggl-button.notion {


### PR DESCRIPTION
Please remember the [Contributing Guidelines](https://github.com/toggl/track-extension/blob/master/docs/CONTRIBUTING.md) :heart:

## :star2: What does this PR do?
Better align the Notion button.
Before:
<img width="352" alt="image" src="https://github.com/toggl/track-extension/assets/860741/eea8473d-29ed-46fc-9a2f-cc3f0ce28d6f">

After:
<img width="352" alt="image" src="https://github.com/toggl/track-extension/assets/860741/6245f183-dc76-402e-9de5-8363d5bf54c1">


<!-- A Concise description of what this PR achieves, including any context. -->

<!-- If you're adding a new integration, please make sure it follows the "style guide" https://github.com/toggl/toggl-button/blob/master/.github/CONTRIBUTING.md -->

## :bug: Recommendations for testing

All changes should be tested across Chrome and Firefox.

<!-- Tips for testing this PR, or anything you want to bring special attention to. -->

## :memo: Links to relevant issues or information

<!-- Link to relevant issues, comments, etc. -->
