### PR TITLE
fix(action): generate release notes in release

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -16,14 +16,16 @@ jobs:
           echo "VERSION=$(echo ${{ github.ref }} | sed -e 's/^refs\/tags\///')" >> $GITHUB_ENV
       - name: Create release
         id: create_release
-        uses: actions/create-release@v1
+        uses: softprops/action-gh-release@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
+          token: ${{ secrets.GITHUB_TOKEN }}
           tag_name: ${{ github.ref }}
-          release_name: Release ${{ env.VERSION }}
+          name: Release ${{ env.VERSION }}
           draft: false
           prerelease: false
+          generate_release_notes: true
       - name: Sync core repo dependency version
         uses: peter-evans/repository-dispatch@v2
         with:


### PR DESCRIPTION
Please remember the [Contributing Guidelines](https://github.com/toggl/track-extension/blob/master/docs/CONTRIBUTING.md) :heart:

## :star2: What does this PR do?

auto generate release notes similar to how we do in core [here](https://github.com/toggl/track-extension-core/blob/9ddb78875a008f1bfb378a893cfb49a244d12625/.github/workflows/pre-release.yml#L201)

<!-- If you're adding a new integration, please make sure it follows the "style guide" https://github.com/toggl/toggl-button/blob/master/.github/CONTRIBUTING.md -->

## :bug: Recommendations for testing

try in new release and hope it works