### PR TITLE
fix(drupal): Fix title retrieval for Drupal.org integration

### DIFF
--- a/src/content/drupal.js
+++ b/src/content/drupal.js
@@ -4,9 +4,14 @@ togglbutton.render(
   'body.node-type-project-issue #tabs ul:not(.toggl)',
   {},
   function (elem) {
+    const getDescription = () => {
+      const descriptionElem = document.getElementById('page-subtitle');
+      return descriptionElem ? descriptionElem.textContent.trim() : '';
+    };
+
     const link = togglbutton.createTimerLink({
       className: 'drupalorg',
-      description: elem.textContent
+      description: getDescription
     });
 
     elem.appendChild(document.createElement('li').appendChild(link));


### PR DESCRIPTION
## :star2: What does this PR do?
Updated the Drupal integration to retrieve the issue title.
<!-- A Concise description of what this PR achieves, including any context. -->

### Demo after fix:

![2024-03-21_22-16](https://github.com/toggl/track-extension/assets/5307506/6a54a0a3-6d41-4c2c-9405-4a084adab770)


<!-- If you're adding a new integration, please make sure it follows the "style guide" https://github.com/toggl/toggl-button/blob/master/.github/CONTRIBUTING.md -->

## :bug: Recommendations for testing
1. Log in [Drupal.org](https://www.drupal.org/);
2. Go to issue page (e.g. https://www.drupal.org/node/2920800);
3. Start Toggl timer;
4. The issue title should be used as the timer entry.

<!-- Tips for testing this PR, or anything you want to bring special attention to. -->

## :memo: Links to relevant issues or information

<!-- Link to relevant issues, comments, etc. -->
Closes #928