### PR TITLE
fix(evernote): Fix placement of Toggl link in UI

### DIFF
--- a/src/content/evernote.js
+++ b/src/content/evernote.js
@@ -26,8 +26,9 @@ togglbutton.render('#qa-NOTE_HEADER:not(.toggl)', { observe: true }, function (e
   });
 
   // Insert at the start of the same header segment as the share button
-  elem
-    .querySelector('#qa-SHARE_BUTTON')
-    .parentNode
-    .prepend(link);
+  const shareButton = elem.querySelector('#qa-SHARE_BUTTON');
+  if (shareButton) {
+      const shareButtonParent = shareButton.parentNode;
+      shareButtonParent.parentNode.prepend(link);
+  }
 });


### PR DESCRIPTION
## :star2: What does this PR do?
Fix placement of Toggl link in UI.
### Before fix
![2024-03-24_00-53](https://github.com/toggl/track-extension/assets/5307506/73bbd246-ea95-43f7-8a37-a11b21fe37f9)

### After fix
![2024-03-24_01-07](https://github.com/toggl/track-extension/assets/5307506/1440e6a8-c126-4174-bad5-6b4f20a0c825)


<!-- A Concise description of what this PR achieves, including any context. -->

<!-- If you're adding a new integration, please make sure it follows the "style guide" https://github.com/toggl/toggl-button/blob/master/.github/CONTRIBUTING.md -->

## :bug: Recommendations for testing

Login to Evernote and open a page with any note.
The Toggl link should be positioned correctly.

<!-- Tips for testing this PR, or anything you want to bring special attention to. -->

## :memo: Links to relevant issues or information

<!-- Link to relevant issues, comments, etc. -->
Closes #2134
