### PR TITLE
fix(github): Add issue number to a timer entry in a GitHub project

### DIFF
--- a/src/content/github.js
+++ b/src/content/github.js
@@ -95,20 +95,28 @@ togglbutton.render(
   ".js-project-card-details .js-comment:not(.toggl)",
   { observe: true },
   function (elem) {
-    const titleElem = $(".js-issue-title");
-    const numElem = $(
-      ".js-project-card-details .project-comment-title-hover span.color-text-tertiary"
-    );
-    const projectElem = $("h1.public strong a, h1.private strong a");
+    const getDescription = () => {
+      const titleElem = $(".js-issue-title");
 
-    let description = titleElem.textContent;
-    if (numElem !== null) {
-      description = numElem.textContent + " " + description.trim();
-    }
+      if (!titleElem) {
+        return "";
+      }
+      const issueNumberElem = $(".js-issue-title + span");
+      const issueTitle = titleElem.textContent.trim();
+
+      // Check if the text starts with a '#' followed by digits, indicating an issue number
+      if (issueNumberElem && /^#\d+/.test(issueNumberElem.textContent)) {
+        return issueNumberElem.textContent.trim() + " " + issueTitle;
+      }
+
+      return issueTitle;
+    };
+
+    const projectElem = $("h1.public strong a, h1.private strong a");
 
     const link = togglbutton.createTimerLink({
       className: "github",
-      description: description,
+      description: getDescription,
       projectName: projectElem && projectElem.textContent,
     });
 


### PR DESCRIPTION

## :star2: What does this PR do?
Updated GitHub integration issue description retrieval to include issue number in timer entry.

### Before

![2024-03-24_17-03](https://github.com/toggl/track-extension/assets/5307506/cf9fa930-1ef8-499d-a413-a75a5eb40a84)

### After 

![2024-03-24_17-04](https://github.com/toggl/track-extension/assets/5307506/ac0de710-4453-4d28-9aff-94324a157c85)

<!-- A Concise description of what this PR achieves, including any context. -->

<!-- If you're adding a new integration, please make sure it follows the "style guide" https://github.com/toggl/toggl-button/blob/master/.github/CONTRIBUTING.md -->

## :bug: Recommendations for testing
Steps to reproduce the behavior:

1. Go to a GitHub project;
2. Click on an issue;
3. Click on "Start timer".

<!-- Tips for testing this PR, or anything you want to bring special attention to. -->

## :memo: Links to relevant issues or information

<!-- Link to relevant issues, comments, etc. -->
Closes #2116
