### PR TITLE
fix(trello): Button was hidden on certain hover conditions

### DIFF
--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -173,13 +173,11 @@ SingleTaskPaneToolbar .toggl-button.asana-board, /* new ui v1 */
 }
 
 .toggl-button.trello-list:not(.toggl-button-edit-form-button) {
-  visibility: hidden;
   pointer-events: none;
   margin-top: 6px;
   margin-left: 1px;
 }
 .checklist-item-details:hover .toggl-button.trello-list, .toggl-button.trello-list.active:not(.toggl-button-edit-form-button) {
-  visibility: visible;
   pointer-events: all;
   height: 100%;
   width: 100%;


### PR DESCRIPTION
Please remember the [Contributing Guidelines](https://github.com/toggl/track-extension/blob/master/docs/CONTRIBUTING.md) :heart:

## :star2: What does this PR do?
Fix this case:
![play](https://github.com/toggl/track-extension/assets/860741/b7afdc4d-0fdf-499f-b1d6-0dbf327cc238)

Observe that the button was hidden and only shows when hovering the list, but not the checkbox.


<!-- A Concise description of what this PR achieves, including any context. -->

<!-- If you're adding a new integration, please make sure it follows the "style guide" https://github.com/toggl/toggl-button/blob/master/.github/CONTRIBUTING.md -->

## :bug: Recommendations for testing

All changes should be tested across Chrome and Firefox.

<!-- Tips for testing this PR, or anything you want to bring special attention to. -->

## :memo: Links to relevant issues or information

<!-- Link to relevant issues, comments, etc. -->
