### PR TITLE
Update visualstudio.js to handle custom project field

### DIFF
--- a/src/content/visualstudio.js
+++ b/src/content/visualstudio.js
@@ -14,8 +14,12 @@ function getContainer (selector) {
   return visibleContainers.length > 0 && visibleContainers[0];
 }
 
-// We need to find proper project element, which differs between old and new layout
 function projectSelector () {
+  // Look for project input field in work item layout and use if it exists
+  const projectInputElement = $('input[aria-label="Project"]');
+  if (projectInputElement) return projectInputElement.value;
+
+  // Otherwise need to find proper project element, which differs between old and new layout
   const oldLayoutProjectElement = $('.tfs-selector span');
   const newLayoutProjectElement = $('.fontWeightHeavy.flex-grow.commandbar-item-text');
   const projectElement = oldLayoutProjectElement || newLayoutProjectElement;


### PR DESCRIPTION
## :star2: What does this PR do?

Updated visualstudio.js to handle custom project field if it exists on the work item page, otherwise fall back to current logic to find project.

## :bug: Recommendations for testing

- In Azure DevOps, customize work item layout for a given work item type (e.g. PBI or Bug)  to include a custom field called "Project", and add some custom values.
- Open a PBI of that type in the work item screen and select a value in the Project dropdown.
- Confirm when clicking the Toggl button, the value from the dropdown is used to populate Project on the time entry.

All changes should be tested across Chrome and Firefox.
