### PR TITLE
fix(sentry): Fix Sentry integration not working

### DIFF
--- a/src/content/sentry.js
+++ b/src/content/sentry.js
@@ -1,16 +1,21 @@
 'use strict';
 
-togglbutton.render('.group-detail:not(.toggl)', { observe: true }, function () {
-  const errType = $('h3 > span > span').textContent.trim();
-  const detail = $('.message').textContent.trim();
-  const project = $('.project-select').textContent.trim();
-  const description = errType + ': ' + detail;
+togglbutton.render('.group-detail:not(.toggl)', { observe: true }, function (elem) {
+  const pageTitle = $('title').textContent.trim();
 
+  // Extract the project name from the page title, assuming it's the last part after ' — '
+  const pageTitleParts = pageTitle.split(' — ');
+  const projectName = pageTitleParts.length > 1 ? pageTitleParts[pageTitleParts.length - 1] : '';
+  
   const link = togglbutton.createTimerLink({
     className: 'sentry',
-    description: description,
-    projectName: project
+    description: pageTitle,
+    projectName: projectName
   });
 
-  $('.group-detail .nav-tabs').appendChild(link);
+  const tabListElement = elem.querySelector('ul[role="tablist"]');
+  if (tabListElement) {
+    tabListElement.appendChild(link);
+  }
 });
+


### PR DESCRIPTION
## :star2: What does this PR do?

<!-- A Concise description of what this PR achieves, including any context. -->
Fix Sentry integration not working: #2328
- Update timer description to use full page title (previous selectors no longer work).
- Extract project name from the page title instead of using the project select element.
- Fixed DOM element selection for appending the timer link.

<!-- If you're adding a new integration, please make sure it follows the "style guide" https://github.com/toggl/toggl-button/blob/master/.github/CONTRIBUTING.md -->

## :bug: Recommendations for testing

All changes should be tested across Chrome and Firefox.

<!-- Tips for testing this PR, or anything you want to bring special attention to. -->
A Toggl button should be available on the Sentry issue page.
## :memo: Links to relevant issues or information

<!-- Link to relevant issues, comments, etc. -->
Closes #2328