### PR TITLE
fix(youtrack): Fix YouTrack issue element selectors

### DIFF
--- a/src/content/youtrack.js
+++ b/src/content/youtrack.js
@@ -49,15 +49,14 @@ togglbutton.render(
   'div[data-test="issue-container"]:not(.toggl)',
   { observe: true },
   function (elem) {
-    console.log('Toggl Button: Reporter info not found.')
-    const reporterInfo = elem.querySelector('span[data-test="reporter-info"]');
+    const reporterInfo = elem.querySelector('[data-test="reporter-info"]');
     if (reporterInfo === null) {
       console.log('Toggl Button: Reporter info not found.')
       return;
     }
     const reporterInfoContainer = reporterInfo.parentElement;
 
-    const issueIdElem = reporterInfoContainer.querySelector('a[href*="issue/"] > span');
+    const issueIdElem = reporterInfoContainer.querySelector('a[href*="issue/"]');
     const issueId = issueIdElem ? issueIdElem.textContent.trim() : "";
 
     const issueTitleElem = elem.querySelector('h1');


### PR DESCRIPTION

## :star2: What does this PR do?
Fix Youtrack integration not working properly: https://github.com/toggl/track-extension/issues/2319
<!-- A Concise description of what this PR achieves, including any context. -->

- Updated selector for reporter info to be more generic (`span` element was changed to `div` on Youtrack).
- Modified issue ID selector to target the anchor element directly (`span` element was removed on Youtrack).
- Removed unnecessary console.log statement.

<!-- If you're adding a new integration, please make sure it follows the "style guide" https://github.com/toggl/toggl-button/blob/master/.github/CONTRIBUTING.md -->

## :bug: Recommendations for testing

All changes should be tested across Chrome and Firefox.

<!-- Tips for testing this PR, or anything you want to bring special attention to. -->
The Toggl button should be tested on the Youtrack issue page.
I tested the fix on the public Jetbrains Youtrack: https://youtrack.jetbrains.com/issues

## :memo: Links to relevant issues or information

<!-- Link to relevant issues, comments, etc. -->
Closes #2319