### PR TITLE
fix(ticktick): Fix TickTick adding extra xxxx at the start of the description

### DIFF
--- a/src/content/ticktick.js
+++ b/src/content/ticktick.js
@@ -7,7 +7,7 @@ togglbutton.render('#task-detail-view:not(.toggl)', { observe: true }, function 
   }
 
   function getDescription () {
-    const descriptionEl = elem.querySelector('.task-title');
+    const descriptionEl = elem.querySelector('.task-title .CodeMirror-code');
     return descriptionEl ? descriptionEl.textContent.trim() : '';
   }
 


### PR DESCRIPTION

## :star2: What does this PR do?
Fix TickTick adding extra xxxx at the start of the description: #2312
- Updated selector for task description element in TickTick integration.
<!-- A Concise description of what this PR achieves, including any context. -->
### Before fix
![2024-09-17_10-07](https://github.com/user-attachments/assets/c3875f3f-8268-4058-ab0a-14a6545b3ca0)
### After fix 
![2024-09-17_10-08](https://github.com/user-attachments/assets/f4a282df-6899-486f-a6c8-4b556a395914)

<!-- If you're adding a new integration, please make sure it follows the "style guide" https://github.com/toggl/toggl-button/blob/master/.github/CONTRIBUTING.md -->

## :bug: Recommendations for testing

All changes should be tested across Chrome and Firefox.

<!-- Tips for testing this PR, or anything you want to bring special attention to. -->
The description of the Toggl timer entry should be without the extra "xxxx" in it.
## :memo: Links to relevant issues or information

<!-- Link to relevant issues, comments, etc. -->
Closes #2312
