### PR TITLE
feat(youtrack): Add Toggl button to YouTrack Agile board issue modal

### DIFF
--- a/src/content/youtrack.js
+++ b/src/content/youtrack.js
@@ -98,3 +98,25 @@ togglbutton.render('.yt-agile-card:not(.toggl)', { observe: true }, function (
 
   container.appendChild(link);
 });
+
+// Agile board - issue modal
+togglbutton.render('div[role="dialog"] div[data-test="fields-sidebar"]:not(.toggl)', { observe: true }, function (
+  elem
+) {
+  const dialog = elem.closest('div[role="dialog"]');
+
+  const issueIdElem = dialog.querySelector('a[href*="issue/"]');
+  const issueId = issueIdElem ? issueIdElem.textContent.trim() : "";
+
+  const issueTitleElem = dialog.querySelector('h1');
+  const issueTitle = issueTitleElem ? issueTitleElem.textContent.trim() : "";
+
+  const link = togglbutton.createTimerLink({
+    className: 'youtrack-modal',
+    description: issueId + ' ' + issueTitle,
+    projectName: issueId.split('-')[0]
+  });
+
+  const container = elem.lastChild;
+  container.insertBefore(link, container.firstChild);
+});

--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -53,6 +53,10 @@
   margin-right: 30px;
 }
 
+.toggl-button.youtrack-modal {
+  padding: 6px 12px;
+}
+
 /********* ASANA *********/
 .toggl-button.asana,
 .toggl-button.asana-new {


### PR DESCRIPTION

Adding Toggl button integration to YouTrack Agile board issue modal: #2316

## Demo:
![image](https://github.com/user-attachments/assets/7c0077ef-7817-4532-8020-9414be78414d)

## :bug: Recommendations for testing

All changes should be tested across Chrome and Firefox.

<!-- Tips for testing this PR, or anything you want to bring special attention to. -->
The Toggl button should appear on the YouTrack Agile board issue modal.
I tested the fix on the public Jetbrains Youtrack: https://youtrack.jetbrains.com/agiles/
## :memo: Links to relevant issues or information

<!-- Link to relevant issues, comments, etc. -->
Closes #2316