### PR TITLE
fix(hubspot): Add toggl button to list view

### DIFF
--- a/src/content/hubspot.js
+++ b/src/content/hubspot.js
@@ -30,3 +30,28 @@ togglbutton.render(
     }
   }
 );
+
+// This generic implementation works for most objects details page
+togglbutton.render(
+  'td[data-table-external-id*="name-"]:not(.toggl)',
+  { observe: true },
+  $container => {
+    try {
+      function descriptionSelector() {
+        return $('[data-test-id="truncated-object-label"]', $container).textContent.trim();
+      }
+
+      const link = togglbutton.createTimerLink({
+        className: 'hubspot-list-item',
+        description: descriptionSelector,
+        buttonType: 'minimal'
+      });
+      const rowContainer = document.createElement('div');
+      rowContainer.setAttribute('class', 'flex-row align-center');
+      rowContainer.appendChild(link);
+      $('.media', $container).prepend(rowContainer);
+    } catch (e) {
+      console.error(e)
+    }
+  }
+);


### PR DESCRIPTION
Please remember the [Contributing Guidelines](https://github.com/toggl/track-extension/blob/master/docs/CONTRIBUTING.md) :heart:

## :star2: What does this PR do?

Make button available in contacts , deals, companies etc most of details pages 
Also in list pages

<img width="702" alt="Screenshot 2024-09-27 at 4 57 36 PM" src="https://github.com/user-attachments/assets/d27b071b-2b5e-4167-9271-d7c43d232ecd">
<img width="382" alt="Screenshot 2024-09-27 at 5 00 38 PM" src="https://github.com/user-attachments/assets/91e8700c-7fdf-44d2-9e88-52068455212c">
<img width="347" alt="Screenshot 2024-09-27 at 5 01 06 PM" src="https://github.com/user-attachments/assets/562d823b-c439-41ff-943d-e6fd2d9708f9">
