### PR TITLE
fix(microsoft): Add new `cloud.microsoft` domains

### DIFF
--- a/src/origins.js
+++ b/src/origins.js
@@ -372,6 +372,11 @@ export default {
     name: 'MeisterTask',
     file: 'meistertask.js'
   },
+  'planner.cloud.microsoft': {
+    url: '*://planner.cloud.microsoft/*',
+    name: 'Microsoft Planner',
+    file: 'microsoft-planner.js'
+  },
   'tasks.office.com': {
     url: '*://tasks.office.com/*',
     name: 'Microsoft Planner'
@@ -429,6 +434,11 @@ export default {
     url: '*://*.supportsystem.com/*',
     name: 'osTicket',
     file: 'osticket.js'
+  },
+  'outlook.cloud.microsoft': {
+    url: '*://outlook.cloud.microsoft/*',
+    name: 'Outlook',
+    file: 'outlook.js'
   },
   'outlook.office.com': {
     url: '*://outlook.office.com/*',


### PR DESCRIPTION
## :star2: What does this PR do?

Map existing integrations to the new Microsoft `cloud.microsoft` domain.
## :bug: Recommendations for testing

All changes should be tested across Chrome and Firefox.

<!-- Tips for testing this PR, or anything you want to bring special attention to. -->

## :memo: Links to relevant issues or information

Changes according to [this](https://learn.microsoft.com/en-us/microsoft-365/enterprise/cloud-microsoft-domain?view=o365-worldwide) blog post.

<!-- Link to relevant issues, comments, etc. -->
