### PR TITLE
add extra parentNode

### DIFF
--- a/src/content/shortcut.js
+++ b/src/content/shortcut.js
@@ -10,7 +10,7 @@ togglbutton.render('#story-dialog-state-dropdown:not(.toggl)', { observe: true }
 ) {
   const wrap = createTag('div');
   const element = elem;
-  elem = elem.parentNode.parentNode.parentNode;
+  elem = elem.parentNode.parentNode.parentNode.parentNode;
 
   const getDescription = function () {
     const storyId = $('.story-id input', elem).value;


### PR DESCRIPTION
Please remember the [Contributing Guidelines](https://github.com/toggl/track-extension/blob/master/docs/CONTRIBUTING.md) :heart:

## :star2: What does this PR do?

Currently, when clicking on the "start timer" button in shortcut, no title is set. This PR looks one div deeper to find the title of the story.

<!-- If you're adding a new integration, please make sure it follows the "style guide" https://github.com/toggl/toggl-button/blob/master/.github/CONTRIBUTING.md -->

## :bug: Recommendations for testing

All changes should be tested across Chrome and Firefox.

- open shortcut.com
- open a card
- click the "start time" button in the actions menu
- verify that the title of the story is automatically added as the title of the time entry.


## :memo: Links to relevant issues or information

<!-- Link to relevant issues, comments, etc. -->
