### PR TITLE
fix(microsoft): Add new `office365.com` domains

### DIFF
--- a/src/origins.js
+++ b/src/origins.js
@@ -386,6 +386,10 @@ export default {
     url: '*://tasks.office.com/*',
     name: 'Microsoft Planner'
   },
+  'tasks.office365.com': {
+    url: '*://tasks.office365.com/*',
+    name: 'Microsoft Planner'
+  },
   'to-do.live.com': {
     url: '*://*.to-do.live.com/*',
     name: 'Microsoft To-Do',
@@ -398,6 +402,11 @@ export default {
   },
   'to-do.office.com': {
     url: '*://*.to-do.office.com/*',
+    name: 'Microsoft To-Do',
+    file: 'microsoft-to-do.js'
+  },
+  'to-do.office365.com': {
+    url: '*://*.to-do.office365.com/*',
     name: 'Microsoft To-Do',
     file: 'microsoft-to-do.js'
   },
@@ -447,6 +456,11 @@ export default {
   },
   'outlook.office.com': {
     url: '*://outlook.office.com/*',
+    name: 'Outlook',
+    file: 'outlook.js'
+  },
+  'outlook.office365.com': {
+    url: '*://outlook.office365.com/*',
     name: 'Outlook',
     file: 'outlook.js'
   },


### PR DESCRIPTION
Please remember the [Contributing Guidelines](https://github.com/toggl/track-extension/blob/master/docs/CONTRIBUTING.md) :heart:

## :star2: What does this PR do?

Map existing integrations to the Microsoft `office365` domain.

<!-- If you're adding a new integration, please make sure it follows the "style guide" https://github.com/toggl/toggl-button/blob/master/.github/CONTRIBUTING.md -->

## :bug: Recommendations for testing

All changes should be tested across Chrome and Firefox.

<!-- Tips for testing this PR, or anything you want to bring special attention to. -->

## :memo: Links to relevant issues or information

<!-- Link to relevant issues, comments, etc. -->
