### PR TITLE
fix(shortcut): Use the dialog parent as context

### DIFF
--- a/src/content/shortcut.js
+++ b/src/content/shortcut.js
@@ -6,21 +6,20 @@
 'use strict';
 
 togglbutton.render('#story-dialog-state-dropdown:not(.toggl)', { observe: true }, function (
-  elem
+  element
 ) {
   const wrap = createTag('div');
-  const element = elem;
-  elem = elem.parentNode.parentNode.parentNode.parentNode;
+  const context = $('#story-dialog-parent');
 
   const getDescription = function () {
-    const storyId = $('.story-id input', elem).value;
-    const title = $('h2.story-name', elem).textContent;
+    const storyId = $('.story-id input', context).value;
+    const title = $('h2.story-name', context).textContent;
 
     return `#${storyId} - ${title}`;
   };
 
   const getProject = function () {
-    return $('.story-epic .value', elem)?.textContent;
+    return $('.story-epic .value', context)?.textContent;
   };
 
   const link = togglbutton.createTimerLink({


### PR DESCRIPTION
Please remember the [Contributing Guidelines](https://github.com/toggl/track-extension/blob/master/docs/CONTRIBUTING.md) :heart:

## :star2: What does this PR do?
- The toggl popup no longer populate the description for the time entry
- Use the story dialog parent as the context for the element queries

<!-- A Concise description of what this PR achieves, including any context. -->

<!-- If you're adding a new integration, please make sure it follows the "style guide" https://github.com/toggl/toggl-button/blob/master/.github/CONTRIBUTING.md -->

## :bug: Recommendations for testing

All changes should be tested across Chrome and Firefox.

<!-- Tips for testing this PR, or anything you want to bring special attention to. -->

## :memo: Links to relevant issues or information

<!-- Link to relevant issues, comments, etc. -->
