### PR TITLE
fix(redbooth): Add button on right panel task drawer

### DIFF
--- a/src/content/redbooth.js
+++ b/src/content/redbooth.js
@@ -2,7 +2,7 @@
 
 // Right side panel
 togglbutton.render(
-  '.js-right-pane .tb-element-big:not(.toggl)',
+  '.l-panes-content--full-expanded .tb-element-big:not(.toggl)',
   { observe: true },
   function (elem) {
     const container = $('.tb-element-title', elem);

--- a/src/content/redbooth.js
+++ b/src/content/redbooth.js
@@ -1,4 +1,9 @@
-'use strict';
+/**
+ * @name Redbooth
+ * @urlAlias redbooth.com
+ * @urlRegex *://redbooth.com/*
+ */
+'use strict'
 
 // Right side panel
 togglbutton.render(

--- a/src/origins.js
+++ b/src/origins.js
@@ -511,8 +511,9 @@ export default {
     name: 'RallyDev'
   },
   'redbooth.com': {
-    url: '*://*.redbooth.com/*',
-    name: 'Redbooth'
+    url: '*://redbooth.com/*',
+    name: 'Redbooth',
+    file: 'redbooth.js'
   },
   'redmine.org': {
     url: '*://*.redmine.org/*',


### PR DESCRIPTION
Please remember the [Contributing Guidelines](https://github.com/toggl/track-extension/blob/master/docs/CONTRIBUTING.md) :heart:

## :star2: What does this PR do?

This PR adds the missing button when opening tasks on right panel

## :bug: Recommendations for testing

1. Go to Dashboard>My Tasks and open a task
2. Toggl Track button should appear in the right panel

## :memo: Links to relevant issues or information

<!-- Link to relevant issues, comments, etc. -->

[Thread](https://toggl.slack.com/archives/C043ZPZQ2JC/p1738932609346419) 🧵
