### PR TITLE
fix(trello): make the button to appear in new ui

### DIFF
--- a/src/content/trello.js
+++ b/src/content/trello.js
@@ -7,9 +7,7 @@
 /* global createTag */
 
 const getProject = () => {
-  const project = document.querySelector(
-    '.board-header [data-testid="board-name-display"]',
-  )
+  const project = document.querySelector('[data-testid="board-name-display"]')
   return project ? project.textContent.trim() : ''
 }
 
@@ -19,9 +17,9 @@ const getCardName = () => {
 
 togglbutton.inject(
   {
-    node: '[data-testid="card-back-move-card-button"]:not(.toggl)',
+    node: '[data-testid="card-back-add-to-card-button"]:not(.toggl)',
     renderer: (element) => {
-      const container = createTag('li', 'button-link trello-tb-wrapper')
+      const container = createTag('div', element.classList.toString())
 
       const link = togglbutton.createTimerLink({
         className: 'trello',
@@ -38,7 +36,7 @@ togglbutton.inject(
 
       container.appendChild(link)
 
-      element.parentNode.parentNode.prepend(container, element)
+      element.parentNode.prepend(container, element)
     },
   },
   { observe: true },


### PR DESCRIPTION
## :star2: What does this PR do?

This PR makes the button to appear again in Trello UI as per screenshot.

<img width="1085" height="415" alt="image" src="https://github.com/user-attachments/assets/9b540cbd-dea6-48b4-9e3a-40fc775dc38d" />

## :bug: Recommendations for testing

1. Open Trello.
2. Ensure that the button appears in the card (and also in the list items when you have tasks inside a card).
3. Ensure that the title is correctly taken.

All changes should be tested across Chrome and Firefox.

## :memo: Links to relevant issues or information

N.D.
