### PR TITLE
fix(trello): fix trello button integration duplication issue

### DIFF
--- a/src/content/trello.js
+++ b/src/content/trello.js
@@ -19,6 +19,10 @@ togglbutton.inject(
   {
     node: '[data-testid="card-back-add-to-card-button"]:not(.toggl)',
     renderer: (element) => {
+      if (element.parentNode.querySelector('.toggl-button.trello')) {
+        return
+      }
+
       const container = createTag('div', element.classList.toString())
 
       const link = togglbutton.createTimerLink({
@@ -50,6 +54,10 @@ togglbutton.injectMany(
     renderer: (elements) => {
       // Loop through all the checklist items.
       for (const element of elements) {
+        if (element.querySelector('.checklist-item-menu .toggl-button')) {
+          continue
+        }
+
         const getTaskText = () => {
           return (
             element.parentNode


### PR DESCRIPTION
## :star2: What does this PR do?

**Issue**

Toggl integration buttons were being duplicated on Trello cards and checklist items.

**Cause**

The duplicate button checks were using inconsistent selectors:
Card buttons checked for `.toggl-button.trello`
Checklist items checked for `.checklist-item-menu .toggl-button`
This inconsistency allowed duplicate buttons to be created when the DOM structure changed or when the render function was called multiple times.

**Solution**

Standardized the duplicate button detection by using consistent CSS selectors across both card and checklist item integrations to properly identify existing Toggl buttons and prevent duplicates.

## :bug: Recommendations for testing

- Enable Trello integration
- Open trello
- Find a card with bigger description
- Scroll down
- Confirm that there is just one toggl buttoon

All changes should be tested across Chrome and Firefox.