### PR TITLE
fix(gitlab): fix gitlab integration button UI issue

### DIFF
--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -121,7 +121,8 @@ SingleTaskPaneToolbar .toggl-button.asana-board, /* new ui v1 */
 
 /********* GITLAB *********/
 .toggl-button.gitlab {
-  margin-top: 7px;
+  margin-left: 6px;
+  vertical-align: middle;
 }
 
 @media (max-width: 991px) {


### PR DESCRIPTION
## :star2: What does this PR do?

**Issue**

Toggl timer button appears misaligned (higher) compared to other elements in GitLab's issue header bar

**Cause**

Timer button used default vertical alignment while GitLab interface uses vertical-align: middle via gl-align-middle class

**Solution**

Updated .toggl-button.gitlab CSS to use vertical-align: middle and added margin-left: 6px for proper spacing to match GitLab's design system

All changes should be tested across Chrome and Firefox.